### PR TITLE
Suppress InternalClass errors on uses of PHPUnit\Framework\ExpectationFailedException

### DIFF
--- a/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
@@ -499,6 +499,7 @@ final class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
 
         self::assertSame(['a', 'b'], (new ClassWithDynamicArgumentsMethod())->dynamicArgumentsMethod('a', 'b'));
 
+        /** @psalm-suppress InternalClass */
         $this->expectException(ExpectationFailedException::class);
 
         self::assertSame(['a', 'b'], $object->dynamicArgumentsMethod('a', 'b'));

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
@@ -415,6 +415,7 @@ final class AccessInterceptorValueHolderFunctionalTest extends TestCase
 
         self::assertSame(['a', 'b'], (new ClassWithDynamicArgumentsMethod())->dynamicArgumentsMethod('a', 'b'));
 
+        /** @psalm-suppress InternalClass */
         $this->expectException(ExpectationFailedException::class);
 
         self::assertSame(['a', 'b'], $object->dynamicArgumentsMethod('a', 'b'));

--- a/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
@@ -377,6 +377,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
 
         self::assertSame(['a', 'b'], (new ClassWithDynamicArgumentsMethod())->dynamicArgumentsMethod('a', 'b'));
 
+        /** @psalm-suppress InternalClass */
         $this->expectException(ExpectationFailedException::class);
 
         self::assertSame(['a', 'b'], $object->dynamicArgumentsMethod('a', 'b'));


### PR DESCRIPTION
These errors will be detected by Psalm if https://github.com/vimeo/psalm/pull/3841 is merged.